### PR TITLE
Before toggling Valet Mode by two-button press, verify fingerprint.

### DIFF
--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -35,7 +35,7 @@ rev = "ab5831"
 
 [dependencies.r503]
 git = "https://github.com/FransUrbo/rust-libs-r503.git"
-rev = "2236cd"
+version = "0.2.0"
 
 [dependencies.debounce]
 git = "https://github.com/FransUrbo/rust-libs-debounce.git"

--- a/code/src/lib_buttons.rs
+++ b/code/src/lib_buttons.rs
@@ -123,17 +123,17 @@ pub async fn read_button(
 
                 {
                     // Verify with a valid fingerprint that we're authorized to change Valet Mode.
-		    let mut fp_scanner = fp_scanner.lock().await;
+                    let mut fp_scanner = fp_scanner.lock().await;
                     if fp_scanner.Wrapper_Verify_Fingerprint().await {
                         error!("Can't match fingerprint");
 
-			// Give it five seconds before we retry.
-			Timer::after_secs(5).await;
+                        // Give it five seconds before we retry.
+                        Timer::after_secs(5).await;
 
-			// Turn off the aura.
-			fp_scanner.Wrapper_AuraSet_Off().await;
+                        // Turn off the aura.
+                        fp_scanner.Wrapper_AuraSet_Off().await;
 
-			// Restart loop.
+                        // Restart loop.
                         continue;
                     } else {
                         // Lock the flash and read old values.

--- a/code/src/lib_buttons.rs
+++ b/code/src/lib_buttons.rs
@@ -11,6 +11,7 @@ use embassy_sync::{
 use embassy_time::{with_deadline, Duration, Instant, Timer};
 
 type FlashMutex = Mutex<NoopRawMutex, Flash<'static, FLASH, Async, FLASH_SIZE>>;
+type ScannerMutex = Mutex<NoopRawMutex, r503::R503<'static, UART0>>;
 
 use debounce;
 
@@ -75,7 +76,7 @@ async fn set_led(
 pub async fn read_button(
     spawner: Spawner,
     flash: &'static FlashMutex,
-    fp_scanner: &'static r503::R503<'static, UART0>,
+    fp_scanner: &'static ScannerMutex,
     button: Button,
     btn_pin: AnyPin,
     led_pin: AnyPin,
@@ -122,8 +123,17 @@ pub async fn read_button(
 
                 {
                     // Verify with a valid fingerprint that we're authorized to change Valet Mode.
+		    let mut fp_scanner = fp_scanner.lock().await;
                     if fp_scanner.Wrapper_Verify_Fingerprint().await {
                         error!("Can't match fingerprint");
+
+			// Give it five seconds before we retry.
+			Timer::after_secs(5).await;
+
+			// Turn off the aura.
+			fp_scanner.Wrapper_AuraSet_Off().await;
+
+			// Restart loop.
                         continue;
                     } else {
                         // Lock the flash and read old values.

--- a/code/src/lib_can_bus.rs
+++ b/code/src/lib_can_bus.rs
@@ -63,10 +63,10 @@ pub async fn write_can(receiver: Receiver<'static, CriticalSectionRawMutex, CANM
                 info!("=> 'Sending start signal to car'");
             }
             CANMessage::EnableValetMode => {
-                info!("=> 'Enable Valet Mode'");
+                info!("=> 'Valet Mode Enabled'");
             }
             CANMessage::DisableValetMode => {
-                info!("=> 'Disable Valet Mode'");
+                info!("=> 'Valet Mode Disabled'");
             }
         }
     }

--- a/code/src/main.rs
+++ b/code/src/main.rs
@@ -163,22 +163,22 @@ async fn main(spawner: Spawner) {
     if config.valet_mode {
         info!("Valet mode, won't check fingerprint");
     } else {
-	loop {
-	    let mut fp_scanner = fp_scanner.lock().await;
-	    if fp_scanner.Wrapper_Verify_Fingerprint().await {
-		error!("Can't match fingerprint - retrying");
+        loop {
+            let mut fp_scanner = fp_scanner.lock().await;
+            if fp_scanner.Wrapper_Verify_Fingerprint().await {
+                error!("Can't match fingerprint - retrying");
 
-		debug!("NeoPixel RED");
-		neopixel.write(&[(255, 0, 0).into()]).await; // RED
+                debug!("NeoPixel RED");
+                neopixel.write(&[(255, 0, 0).into()]).await; // RED
 
-		// Give it five seconds before we retry.
-		Timer::after_secs(5).await;
-	    } else {
-		info!("Fingerprint matches, use authorized");
-		break;
-	    }
-	    fp_scanner.Wrapper_AuraSet_Off().await; // Turn off the aura.
-	}
+                // Give it five seconds before we retry.
+                Timer::after_secs(5).await;
+            } else {
+                info!("Fingerprint matches, use authorized");
+                break;
+            }
+            fp_scanner.Wrapper_AuraSet_Off().await; // Turn off the aura.
+        }
     }
     neopixel.write(&[(0, 255, 0).into()]).await; // GREEN
 

--- a/code/src/main.rs
+++ b/code/src/main.rs
@@ -143,7 +143,7 @@ async fn main(spawner: Spawner) {
     // =====
     //  9. Initialize the fingerprint scanner.
     CHANNEL_CANWRITE.send(CANMessage::InitFP).await;
-    let mut fp_scanner = r503::R503::new(
+    let fp_scanner = r503::R503::new(
         p.UART0,
         Irqs,
         p.PIN_16,
@@ -153,6 +153,9 @@ async fn main(spawner: Spawner) {
         p.PIN_13.into(),
     );
     CHANNEL_CANWRITE.send(CANMessage::FPInitialized).await;
+
+    static MY_FP_SCANNER: StaticCell<r503::R503<UART0>> = StaticCell::new();
+    let fp_scanner = MY_FP_SCANNER.init(fp_scanner);
 
     // Send message to IC: "Authorizing use".
     CHANNEL_CANWRITE.send(CANMessage::Authorizing).await;
@@ -187,6 +190,7 @@ async fn main(spawner: Spawner) {
         .spawn(read_button(
             spawner,
             flash,
+            fp_scanner,
             Button::P,
             p.PIN_2.degrade(),
             p.PIN_6.degrade(),
@@ -196,6 +200,7 @@ async fn main(spawner: Spawner) {
         .spawn(read_button(
             spawner,
             flash,
+            fp_scanner,
             Button::R,
             p.PIN_3.degrade(),
             p.PIN_7.degrade(),
@@ -205,6 +210,7 @@ async fn main(spawner: Spawner) {
         .spawn(read_button(
             spawner,
             flash,
+            fp_scanner,
             Button::N,
             p.PIN_0.degrade(),
             p.PIN_8.degrade(),
@@ -214,6 +220,7 @@ async fn main(spawner: Spawner) {
         .spawn(read_button(
             spawner,
             flash,
+            fp_scanner,
             Button::D,
             p.PIN_1.degrade(),
             p.PIN_9.degrade(),


### PR DESCRIPTION
NOTE: Isn't currently working.. Borrows.. AGAIN!!
```
error[E0596]: cannot borrow `*fp_scanner` as mutable, as it is behind a `&` reference
   --> src/lib_buttons.rs:125:24
    |
125 |                     if fp_scanner.Wrapper_Verify_Fingerprint().await {
    |                        ^^^^^^^^^^ `fp_scanner` is a `&` reference, so the data it refers to cannot be borrowed as mutable
    |
help: consider specifying this binding's type
    |
78  |     fp_scanner: &mut R503<'_, UART0>: &'static r503::R503<'static, UART0>,
    |               ++++++++++++++++++++++
```