### PR TITLE
Run some of the processes on CORE1.

### DIFF
--- a/code/src/drive-by-wire.rs
+++ b/code/src/drive-by-wire.rs
@@ -165,7 +165,7 @@ async fn main(spawner: Spawner) {
                 spawner.spawn(unwrap!(core1_tasks(
                     spawner,
                     CHANNEL_ACTUATOR.receiver(),
-                    flash,
+//                    flash,
                     actuator,
                     r.watchdog
                 )))

--- a/code/src/drive-by-wire.rs
+++ b/code/src/drive-by-wire.rs
@@ -3,18 +3,18 @@
 
 use defmt::{debug, error, info, unwrap};
 
-use embassy_executor::Spawner;
+use embassy_executor::{Executor, Spawner};
 use embassy_rp::{
     adc::InterruptHandler as ADCInterruptHandler,
     bind_interrupts,
     gpio::{Level, Output},
+    multicore::{spawn_core1, Stack},
     peripherals::{PIO0, UART0, UART1},
     pio::{InterruptHandler as PIOInterruptHandler, Pio},
-    uart::{Blocking, Config as UartConfig, InterruptHandler as UARTInterruptHandler, UartTx},
-    watchdog::*,
+    uart::{Blocking, Config as UartConfig, InterruptHandler as UARTInterruptHandler, UartTx}
 };
 use embassy_sync::mutex::Mutex;
-use embassy_time::{Duration, Timer};
+use embassy_time::Timer;
 
 use static_cell::StaticCell;
 
@@ -31,19 +31,21 @@ pub mod lib_can_bus;
 pub mod lib_config;
 pub mod lib_resources;
 pub mod lib_watchdog;
+pub mod lib_core1;
 
-use crate::lib_actuator::{actuator_control, CHANNEL_ACTUATOR};
+use crate::lib_actuator::CHANNEL_ACTUATOR;
 use crate::lib_buttons::{
     read_button, Button, LedStatus, ScannerMutex, BUTTON_ENABLED, CHANNEL_D, CHANNEL_N, CHANNEL_P,
     CHANNEL_R,
 };
-use crate::lib_can_bus::{read_can, write_can, CANMessage, CHANNEL_CANWRITE};
+use crate::lib_can_bus::{write_can, CANMessage, CHANNEL_CANWRITE};
 use crate::lib_config::{DbwConfig, init_flash};
 use crate::lib_resources::{
     AssignedResources, PeriActuator, PeriBuiltin, PeriButtons, PeriFPScanner, PeriFlash,
     PeriNeopixel, PeriSerial, PeriStart, PeriSteering, PeriWatchdog,
 };
-use crate::lib_watchdog::{feed_watchdog, StopWatchdog, CHANNEL_WATCHDOG};
+use crate::lib_watchdog::{StopWatchdog, CHANNEL_WATCHDOG};
+use crate::lib_core1::core1_tasks;
 
 // DMA Channels used (of 12):
 // * Fingerprint scanner:	UART0	DMA_CH[0-1]	PIN_13, PIN_16, PIN_17
@@ -56,6 +58,9 @@ bind_interrupts!(struct Irqs {
     UART1_IRQ    => UARTInterruptHandler<UART1>;	// Serial logging
     ADC_IRQ_FIFO => ADCInterruptHandler;		// Actuator potentiometer
 });
+
+static mut CORE1_STACK: Stack<4096> = Stack::new();
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 // ================================================================================
 
@@ -97,31 +102,22 @@ async fn main(spawner: Spawner) {
     neopixel.set_colour(Colour::ORANGE).await;
 
     // =====
-    //  4. Initialize the watchdog. Needs to be second, so it'll restart if something goes wrong.
-    let mut watchdog = Watchdog::new(r.watchdog.peri);
-    watchdog.start(Duration::from_millis(1_050));
-    spawner.spawn(unwrap!(feed_watchdog(
-        CHANNEL_WATCHDOG.receiver(),
-        watchdog
-    )));
-    info!("Watchdog timer initialized");
-
-    // =====
-    //  5. Initialize the CAN bus. Needs to come third, so we can talk to the IC.
-    spawner.spawn(unwrap!(read_can()));
+    //  4. Initialize the CAN bus. Needs to come as early as possible, so we can talk to the IC.
+    //     NOTE: `read_can()` is spawned on CORE1 in `core1_tasks()` a bit later, because at this
+    //           point we don't actually need to read the CAN.
     spawner.spawn(unwrap!(write_can(CHANNEL_CANWRITE.receiver())));
-    info!("CAN bus communicators initialized");
+    info!("CAN bus writer runing");
     CHANNEL_CANWRITE.send(CANMessage::Starting).await;
 
     // =====
-    //  6. Initialize the MOSFET relays.
+    //  5. Initialize the MOSFET relays.
     let mut eis_steering_lock = Output::new(r.steering.pin, Level::Low); // EIS/Steering lock (GREEN)
     let mut eis_start = Output::new(r.start.pin, Level::Low); // EIS/Start (YELLOW)
     info!("EIS relays initialized");
     CHANNEL_CANWRITE.send(CANMessage::RelaysInitialized).await;
 
     // =====
-    //  7. Initialize the flash drive where we store some config values across reboots.
+    //  6. Initialize the flash drive where we store the state across reboots.
     info!("Initializing the flash drive");
     let flash = init_flash(r.flash);
 
@@ -134,7 +130,7 @@ async fn main(spawner: Spawner) {
     info!("{:?}", config);
 
     // =====
-    //  8. Initialize and test the actuator.
+    //  7a. Initialize and test the actuator.
     info!("Initializing actuator");
     CHANNEL_CANWRITE.send(CANMessage::InitActuator).await;
     let mut actuator = Actuator::new(
@@ -146,7 +142,7 @@ async fn main(spawner: Spawner) {
         Irqs,
     );
 
-    // Test actuator control.
+    // 7b. Test actuator control.
     if !actuator.test_actuator().await {
         // ERROR: Actuator have not moved.
         error!("Actuator failed to move - resetting");
@@ -156,17 +152,29 @@ async fn main(spawner: Spawner) {
         CHANNEL_WATCHDOG.send(StopWatchdog::Yes).await;
     }
 
-    // Actuator works. Spawn off the actuator control task.
-    spawner.spawn(unwrap!(actuator_control(
-        CHANNEL_ACTUATOR.receiver(),
-        flash,
-        actuator
-    )));
-    info!("Actuator initialized");
-    CHANNEL_CANWRITE.send(CANMessage::ActuatorInitialized).await;
+    //  8. Spawn off tasks on CORE1.
+    //     * Watchdog.
+    //     * Actuator control.
+    //     * CAN reader.
+    spawn_core1(
+        p.CORE1,
+        unsafe { &mut *core::ptr::addr_of_mut!(CORE1_STACK) },
+        move || {
+            let executor = EXECUTOR.init(Executor::new());
+            executor.run(|spawner| {
+                spawner.spawn(unwrap!(core1_tasks(
+                    spawner,
+                    CHANNEL_ACTUATOR.receiver(),
+                    flash,
+                    actuator,
+                    r.watchdog
+                )))
+            });
+        },
+    );
 
     // =====
-    //  9. Initialize the fingerprint scanner.
+    // 9a. Initialize the fingerprint scanner.
     info!("Initializing the fingerprint scanner");
     CHANNEL_CANWRITE.send(CANMessage::InitFP).await;
     let fp_scanner = R503::new(
@@ -183,7 +191,7 @@ async fn main(spawner: Spawner) {
     info!("Fingerprint scanner initialized");
     CHANNEL_CANWRITE.send(CANMessage::FPInitialized).await;
 
-    // Verify fingerprint.
+    // 9b. Verify fingerprint.
     info!("Authorizing use");
     CHANNEL_CANWRITE.send(CANMessage::Authorizing).await;
     if config.valet_mode {

--- a/code/src/lib_actuator.rs
+++ b/code/src/lib_actuator.rs
@@ -1,4 +1,4 @@
-use defmt::{error, info};
+use defmt::info;
 
 use embassy_sync::{
     blocking_mutex::raw::CriticalSectionRawMutex,
@@ -7,7 +7,6 @@ use embassy_sync::{
 
 // External "defines".
 use crate::lib_buttons::{Button, BUTTONS_BLOCKED, BUTTON_ENABLED};
-use crate::lib_config::{resonable_defaults, write_flash, DbwConfig, FlashMutex};
 
 use actuator::Actuator;
 
@@ -18,7 +17,7 @@ pub static CHANNEL_ACTUATOR: Channel<CriticalSectionRawMutex, Button, 64> = Chan
 #[embassy_executor::task]
 pub async fn actuator_control(
     receiver: Receiver<'static, CriticalSectionRawMutex, Button, 64>,
-    flash: &'static FlashMutex,
+//    flash: &'static FlashMutex,
     mut actuator: Actuator<'static>,
 ) {
     info!("Started actuator control task");
@@ -38,25 +37,25 @@ pub async fn actuator_control(
         // .. and update the button enabled.
         unsafe { BUTTON_ENABLED = button };
 
-        // .. and write it to flash.
-        {
-            // Read the existing values from the flash.
-            // The flash lock is released when it goes out of scope.
-            let mut flash = flash.lock().await;
-            let mut config = match DbwConfig::read(&mut flash) {
-                // Read the old/current values.
-                Ok(config) => config,
-                Err(e) => {
-                    error!("Failed to read flash: {:?}", e);
-                    resonable_defaults()
-                }
-            };
+        // // .. and write it to flash.
+        // {
+        //     // Read the existing values from the flash.
+        //     // The flash lock is released when it goes out of scope.
+        //     let mut flash = flash.lock().await;
+        //     let mut config = match DbwConfig::read(&mut flash) {
+        //         // Read the old/current values.
+        //         Ok(config) => config,
+        //         Err(e) => {
+        //             error!("Failed to read flash: {:?}", e);
+        //             resonable_defaults()
+        //         }
+        //     };
 
-            // Set new value.
-            config.active_button = button;
+        //     // Set new value.
+        //     config.active_button = button;
 
-            // Write the config to flash.
-            write_flash(&mut flash, config).await;
-        }
+        //     // Write the config to flash.
+        //     write_flash(&mut flash, config).await;
+        // }
     }
 }

--- a/code/src/lib_core1.rs
+++ b/code/src/lib_core1.rs
@@ -11,7 +11,6 @@ use embassy_sync::{
 use crate::lib_actuator::actuator_control;
 use crate::lib_buttons::Button;
 use crate::lib_can_bus::{read_can, CANMessage, CHANNEL_CANWRITE};
-use crate::lib_config::FlashMutex;
 use crate::lib_watchdog::{feed_watchdog, CHANNEL_WATCHDOG};
 use crate::lib_resources::PeriWatchdog;
 
@@ -21,7 +20,7 @@ use actuator::Actuator;
 pub async fn core1_tasks(
     spawner: Spawner,
     receiver: Receiver<'static, CriticalSectionRawMutex, Button, 64>,
-    flash: &'static FlashMutex,
+//    flash: &'static FlashMutex,
     actuator: Actuator<'static>,
     watchdog: PeriWatchdog
 ) {
@@ -41,7 +40,7 @@ pub async fn core1_tasks(
     // Spawn the Actuator controller.
     spawner.spawn(unwrap!(actuator_control(
         receiver,
-        flash,
+//        flash,
         actuator
     )));
     info!("Actuator controller running");

--- a/code/src/lib_core1.rs
+++ b/code/src/lib_core1.rs
@@ -1,0 +1,54 @@
+use defmt::{info, unwrap};
+
+use embassy_executor::Spawner;
+use embassy_rp::watchdog::*;
+use embassy_time::Duration;
+use embassy_sync::{
+    blocking_mutex::raw::CriticalSectionRawMutex,
+    channel::Receiver
+};
+
+use crate::lib_actuator::actuator_control;
+use crate::lib_buttons::Button;
+use crate::lib_can_bus::{read_can, CANMessage, CHANNEL_CANWRITE};
+use crate::lib_config::FlashMutex;
+use crate::lib_watchdog::{feed_watchdog, CHANNEL_WATCHDOG};
+use crate::lib_resources::PeriWatchdog;
+
+use actuator::Actuator;
+
+#[embassy_executor::task]
+pub async fn core1_tasks(
+    spawner: Spawner,
+    receiver: Receiver<'static, CriticalSectionRawMutex, Button, 64>,
+    flash: &'static FlashMutex,
+    actuator: Actuator<'static>,
+    watchdog: PeriWatchdog
+) {
+    info!("Spawning tasks on CORE1");
+
+    // -----
+    // Spawn Watchdog.
+    let mut watchdog = Watchdog::new(watchdog.peri);
+    watchdog.start(Duration::from_millis(1_050));
+    spawner.spawn(unwrap!(feed_watchdog(
+        CHANNEL_WATCHDOG.receiver(),
+        watchdog
+    )));
+    info!("Watchdog timer running");
+
+    // -----
+    // Spawn the Actuator controller.
+    spawner.spawn(unwrap!(actuator_control(
+        receiver,
+        flash,
+        actuator
+    )));
+    info!("Actuator controller running");
+    CHANNEL_CANWRITE.send(CANMessage::ActuatorInitialized).await;
+
+    // -----
+    // Spawn the CAN reader.
+    spawner.spawn(unwrap!(read_can()));
+    info!("CAN bus reader runing");
+}


### PR DESCRIPTION
* Watchdog.
* Actuator control.
* CAN reader.

Because I have to spawn ONE task on CORE1, which can then spawn others, this means that the Watchdog and the CAN reader tasks start a little later than I had hoped, but in the end it shouldn't matter.

Unfortunately, I can't seem to get the flash to be borrowed to the CORE1 task (which need it so that the actuator controller can borrow it) - I'm getting a compile error.

So at the moment, the active button won't be saved to the flash when actuator have moved. I'll see if I can get that fixed somehow.

I've asked on the Rust forum:
* https://users.rust-lang.org/t/mutex-and-multicore/137730/4
* https://users.rust-lang.org/t/using-the-flash-and-gpio-at-the-same-time-on-a-rpi-pico/137771/3