### PR TITLE
Rewrite the flash handler.

### DIFF
--- a/code/src/lib_actuator.rs
+++ b/code/src/lib_actuator.rs
@@ -7,6 +7,7 @@ use embassy_sync::{
 
 // External "defines".
 use crate::lib_buttons::{Button, BUTTONS_BLOCKED, BUTTON_ENABLED};
+use crate::lib_config::{FlashConfigMessages, CHANNEL_FLASH};
 
 use actuator::Actuator;
 
@@ -17,7 +18,6 @@ pub static CHANNEL_ACTUATOR: Channel<CriticalSectionRawMutex, Button, 64> = Chan
 #[embassy_executor::task]
 pub async fn actuator_control(
     receiver: Receiver<'static, CriticalSectionRawMutex, Button, 64>,
-//    flash: &'static FlashMutex,
     mut actuator: Actuator<'static>,
 ) {
     info!("Started actuator control task");
@@ -37,25 +37,7 @@ pub async fn actuator_control(
         // .. and update the button enabled.
         unsafe { BUTTON_ENABLED = button };
 
-        // // .. and write it to flash.
-        // {
-        //     // Read the existing values from the flash.
-        //     // The flash lock is released when it goes out of scope.
-        //     let mut flash = flash.lock().await;
-        //     let mut config = match DbwConfig::read(&mut flash) {
-        //         // Read the old/current values.
-        //         Ok(config) => config,
-        //         Err(e) => {
-        //             error!("Failed to read flash: {:?}", e);
-        //             resonable_defaults()
-        //         }
-        //     };
-
-        //     // Set new value.
-        //     config.active_button = button;
-
-        //     // Write the config to flash.
-        //     write_flash(&mut flash, config).await;
-        // }
+        // ... and update the flash.
+        CHANNEL_FLASH.send(FlashConfigMessages::from(button)).await;
     }
 }

--- a/code/src/lib_can_bus.rs
+++ b/code/src/lib_can_bus.rs
@@ -22,6 +22,7 @@ pub enum CANMessage {
     Authorizing,
     Authorized,
 }
+
 pub static CHANNEL_CANWRITE: Channel<CriticalSectionRawMutex, CANMessage, 64> = Channel::new();
 
 // Write messages to CAN-bus.

--- a/code/src/lib_config.rs
+++ b/code/src/lib_config.rs
@@ -1,40 +1,115 @@
 use defmt::{debug, error, info, trace, Format};
 
 use embassy_rp::{
-    flash::{Async, Error, Flash, ERASE_SIZE},
+    flash::{Async, Flash, ERASE_SIZE},
     peripherals::FLASH,
 };
-use embassy_sync::{blocking_mutex::raw::NoopRawMutex, mutex::Mutex};
+use embassy_sync::{
+    blocking_mutex::raw::{CriticalSectionRawMutex, NoopRawMutex},
+    channel::Channel as SyncChannel,
+    mutex::Mutex,
+};
 
 use static_cell::StaticCell;
 
 // External "defines".
-use crate::Button;
 use crate::lib_resources::{PeriFlash, ADDR_OFFSET, FLASH_SIZE};
+use crate::Button;
 
 pub type FlashMutex = Mutex<NoopRawMutex, Flash<'static, FLASH, Async, FLASH_SIZE>>;
 
-// What we store in flash.
-#[derive(Format)]
-pub struct DbwConfig {
-    pub active_button: Button,
-    pub valet_mode: bool,
+#[derive(PartialEq)]
+pub enum FlashConfigMessages {
+    ValetOn,
+    ValetOff,
+    ButtonP,
+    ButtonR,
+    ButtonN,
+    ButtonD,
+    ReadValet,
+    ReadButton,
 }
 
-impl DbwConfig {
-    fn as_array(&self) -> [u8; 2] {
+impl FlashConfigMessages {
+    // Translate a button to config message.
+    pub fn from(b: Button) -> FlashConfigMessages {
+        match b {
+            Button::P => FlashConfigMessages::ButtonP,
+            Button::R => FlashConfigMessages::ButtonR,
+            Button::N => FlashConfigMessages::ButtonN,
+            Button::D => FlashConfigMessages::ButtonD,
+        }
+    }
+
+    pub fn to_button(m: &Self) -> Button {
+        match m {
+            Self::ButtonP => Button::P,
+            Self::ButtonR => Button::R,
+            Self::ButtonN => Button::N,
+            Self::ButtonD => Button::D,
+            _ => Button::P,
+        }
+    }
+
+    pub fn to_valet(m: Self) -> bool {
+        match m {
+            Self::ValetOn => true,
+            Self::ValetOff => false,
+            _ => false,
+        }
+    }
+}
+
+pub static CHANNEL_FLASH: SyncChannel<CriticalSectionRawMutex, FlashConfigMessages, 64> =
+    SyncChannel::new();
+
+// What we store in flash.
+#[derive(Format)]
+pub struct DbwConfig<'d> {
+    flash: Flash<'d, FLASH, Async, FLASH_SIZE>,
+    active_button: Button,
+    valet_mode: bool,
+}
+
+impl<'d> DbwConfig<'d> {
+    pub fn new(r: PeriFlash) -> Self {
+        info!("Initializing the flash drive");
+
+        let f = Flash::<_, Async, FLASH_SIZE>::new(r.peri, r.dma);
+
+        Self {
+            flash: f,
+            active_button: Button::P,
+            valet_mode: false,
+        }
+    }
+
+    // Translate a button to config message.
+    pub fn from(&mut self, b: Button) -> FlashConfigMessages {
+        match b {
+            Button::P => FlashConfigMessages::ButtonP,
+            Button::R => FlashConfigMessages::ButtonR,
+            Button::N => FlashConfigMessages::ButtonN,
+            Button::D => FlashConfigMessages::ButtonD,
+        }
+    }
+
+    fn as_array(&mut self) -> [u8; 2] {
         [self.active_button as u8, self.valet_mode as u8]
     }
 
-    pub fn read(flash: &mut Flash<'_, FLASH, Async, FLASH_SIZE>) -> Result<DbwConfig, Error> {
+    fn read(&mut self) -> bool {
         let mut read_buf = [0u8; ERASE_SIZE];
 
-        match flash.blocking_read(ADDR_OFFSET + ERASE_SIZE as u32, &mut read_buf) {
+        match self
+            .flash
+            .blocking_read(ADDR_OFFSET + ERASE_SIZE as u32, &mut read_buf)
+        {
             Ok(_) => {
                 debug!("Flash read successful");
 
                 // Translate the u8's.
-                let active_button = match read_buf[0] {
+                self.active_button = match read_buf[0] {
                     0 => Button::P,
                     1 => Button::R,
                     2 => Button::N,
@@ -42,78 +117,124 @@ impl DbwConfig {
                     _ => Button::P, // Never going to happen, but just to keep the compiler happy with resonable default
                 };
 
-                let valet_mode = match read_buf[1] {
+                self.valet_mode = match read_buf[1] {
                     0 => false,
                     1 => true,
-                    _ => true, // Never going to happen, but just to keep the compiler happy with resonable default
+                    _ => false, // Never going to happen, but just to keep the compiler happy with resonable default
                 };
 
-                Ok(DbwConfig {
-                    active_button,
-                    valet_mode,
-                })
+                return true;
             }
             Err(e) => {
                 error!("Flash read failed: {}", e);
-
-                // Still return ok, but with resonable default instead.
-                Ok(resonable_defaults())
+                return false;
             }
         }
     }
 
-    pub fn write(
-        flash: &mut Flash<'_, FLASH, Async, FLASH_SIZE>,
-        config: Self,
-    ) -> Result<(), Error> {
-        // Convert our struct to an array, so we can loop through it easier.
-        let buf: [u8; 2] = config.as_array();
+    fn write(&mut self) -> bool {
+        // Read the flash..
+        if self.read() {
+            debug!(
+                "Config (before write): active_button={:?}, valet_mode={:?}",
+                self.active_button, self.valet_mode
+            );
+        } else {
+            error!("Failed to read (before write)");
+            return false;
+        }
 
+        // Erase the flash..
+        match self.flash.blocking_erase(
+            ADDR_OFFSET + ERASE_SIZE as u32,
+            ADDR_OFFSET + ERASE_SIZE as u32 + ERASE_SIZE as u32,
+        ) {
+            Ok(_) => trace!("Flash erase successful"),
+            Err(e) => {
+                error!("Flash erase failed: {}", e);
+                return false;
+            }
+        }
+
+        // Write the flash..
+        let buf: [u8; 2] = self.as_array(); // Convert our struct to an array, so we can loop through it easier.
         for (j, b) in buf.into_iter().enumerate() {
-            match flash.blocking_write(ADDR_OFFSET + ERASE_SIZE as u32 + j as u32, &[b] as &[u8]) {
+            match self
+                .flash
+                .blocking_write(ADDR_OFFSET + ERASE_SIZE as u32 + j as u32, &[b] as &[u8])
+            {
                 Ok(_) => trace!("Flash write {} successful", j),
                 Err(e) => {
                     error!("Flash write {} failed: {}", j, e);
-                    return Err(e);
+                    return false;
                 }
             }
         }
 
-        Ok(())
+        if self.read() {
+            debug!(
+                "Config (after write): active_button={:?}, valet_mode={:?}",
+                self.active_button, self.valet_mode
+            );
+        } else {
+            error!("Failed to read (before write)");
+            return false;
+        }
+
+        return true;
     }
 }
 
-pub async fn write_flash(flash: &mut Flash<'_, FLASH, Async, FLASH_SIZE>, buf: DbwConfig) {
-    trace!("write_flash({:?})", buf);
+#[embassy_executor::task]
+pub async fn flash_control(r: PeriFlash) {
+    let mut config = DbwConfig::new(r);
 
-    match DbwConfig::read(flash) {
-        Ok(v) => debug!("Config (before write): {:?}", v),
-        Err(e) => error!("Failed to read (before write): {:?}", e),
-    }
+    config.read(); // Read the values from the flash before we begin.
+    loop {
+        match CHANNEL_FLASH.receive().await {
+            // We're asked to *change* a value.
+            FlashConfigMessages::ValetOn => config.valet_mode = true,
+            FlashConfigMessages::ValetOff => config.valet_mode = false,
 
-    match flash.blocking_erase(
-        ADDR_OFFSET + ERASE_SIZE as u32,
-        ADDR_OFFSET + ERASE_SIZE as u32 + ERASE_SIZE as u32,
-    ) {
-        Ok(_) => trace!("Flash erase successful"),
-        Err(e) => error!("Flash erase failed: {}", e),
-    }
+            FlashConfigMessages::ButtonP => config.active_button = Button::P,
+            FlashConfigMessages::ButtonR => config.active_button = Button::R,
+            FlashConfigMessages::ButtonN => config.active_button = Button::N,
+            FlashConfigMessages::ButtonD => config.active_button = Button::D,
 
-    match DbwConfig::write(flash, buf) {
-        Ok(_) => info!("Config update successful"),
-        Err(e) => error!("Config update failed: {}", e),
-    }
+            // We're asked to *read* (and return!) a value.
+            // TODO: How do we send to the one messaging us!?
+            FlashConfigMessages::ReadValet => {
+                debug!(
+                    "Message: FlashConfigMessages::ReadValet: {}",
+                    config.valet_mode
+                );
 
-    match DbwConfig::read(flash) {
-        Ok(v) => debug!("Config (after write): {:?}", v),
-        Err(e) => error!("Failed to read (before write): {:?}", e),
-    }
-}
+                // TODO: This just messages ourselves!
+                // if config.valet_mode {
+                //     CHANNEL_FLASH.send(FlashConfigMessages::ValetOn).await;
+                // } else {
+                //     CHANNEL_FLASH.send(FlashConfigMessages::ValetOff).await;
+                // }
+            }
 
-pub fn resonable_defaults() -> DbwConfig {
-    DbwConfig {
-        active_button: Button::P,
-        valet_mode: false,
+            FlashConfigMessages::ReadButton => {
+                debug!(
+                    "Message: FlashConfigMessages::ReadButton: {}",
+                    config.active_button
+                );
+
+                // TODO: This just messages ourselves!
+                // match config.active_button {
+                //     Button::P => CHANNEL_FLASH.send(config.from(Button::P)).await,
+                //     Button::R => CHANNEL_FLASH.send(config.from(Button::R)).await,
+                //     Button::N => CHANNEL_FLASH.send(config.from(Button::N)).await,
+                //     Button::D => CHANNEL_FLASH.send(config.from(Button::D)).await,
+                // };
+            }
+        };
+
+        // TODO: We're actually writing the new value *after* we've told the sender the (new) value!
+        config.write();
     }
 }
 

--- a/code/src/prepare-flash.rs
+++ b/code/src/prepare-flash.rs
@@ -26,7 +26,7 @@ pub mod lib_config;
 use crate::lib_buttons::Button;
 use crate::lib_resources::{
     AssignedResources, PeriActuator, PeriBuiltin, PeriButtons, PeriFPScanner, PeriFlash,
-    PeriNeopixel, PeriSerial, PeriStart, PeriSteering, PeriWatchdog, ADDR_OFFSET, FLASH_SIZE
+    PeriNeopixel, PeriSerial, PeriStart, PeriSteering, PeriWatchdog, ADDR_OFFSET, FLASH_SIZE,
 };
 use crate::lib_config::init_flash;
 

--- a/code/src/set-valet-mode.rs
+++ b/code/src/set-valet-mode.rs
@@ -8,7 +8,8 @@
 //! The read and write functionality was removed, don't need it.
 //! I just need it to clear the flash area I'm using in the main app.
 
-use defmt::{error, info};
+use defmt::info;
+
 use embassy_executor::Spawner;
 
 pub mod lib_actuator;
@@ -18,36 +19,15 @@ pub mod lib_config;
 pub mod lib_resources;
 
 use crate::lib_buttons::Button;
-use crate::lib_config::{DbwConfig, init_flash};
-use crate::lib_resources::{
-    AssignedResources, PeriActuator, PeriBuiltin, PeriButtons, PeriFPScanner, PeriFlash,
-    PeriNeopixel, PeriSerial, PeriStart, PeriSteering, PeriWatchdog,
-};
+use crate::lib_config::{FlashConfigMessages, CHANNEL_FLASH};
 
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
-    let p = embassy_rp::init(Default::default());
-    let r = split_resources! {p};
-
     info!("Setting valet mode in flash");
 
-    // Instantiate the flash.
-    let flash = init_flash(r.flash);
-
-    // Read old values.
-    let mut flash = flash.lock().await;
-    match DbwConfig::read(&mut flash) {
-        Ok(mut config) => {
-            // Set the valet mode to true.
-            config.valet_mode = true;
-
-            // Write flash.
-            lib_config::write_flash(&mut flash, config).await;
-        }
-        Err(e) => error!("Failed to read flash: {:?}", e),
-    }
+    CHANNEL_FLASH.send(FlashConfigMessages::ValetOff).await;
 
     #[allow(clippy::empty_loop)]
     loop {}

--- a/code/src/unset-valet-mode.rs
+++ b/code/src/unset-valet-mode.rs
@@ -8,7 +8,7 @@
 //! The read and write functionality was removed, don't need it.
 //! I just need it to clear the flash area I'm using in the main app.
 
-use defmt::{error, info};
+use defmt::info;
 use embassy_executor::Spawner;
 
 pub mod lib_actuator;
@@ -18,36 +18,15 @@ pub mod lib_config;
 pub mod lib_resources;
 
 use crate::lib_buttons::Button;
-use crate::lib_config::{DbwConfig, init_flash};
-use crate::lib_resources::{
-    AssignedResources, PeriActuator, PeriBuiltin, PeriButtons, PeriFPScanner, PeriFlash,
-    PeriNeopixel, PeriSerial, PeriStart, PeriSteering, PeriWatchdog,
-};
+use crate::lib_config::{FlashConfigMessages, CHANNEL_FLASH};
 
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
-    let p = embassy_rp::init(Default::default());
-    let r = split_resources! {p};
-
     info!("Unsetting valet mode in flash");
 
-    // Instantiate the flash.
-    let flash = init_flash(r.flash);
-
-    // Read old values.
-    let mut flash = flash.lock().await;
-    match DbwConfig::read(&mut flash) {
-        Ok(mut config) => {
-            // Set the valet mode to false.
-            config.valet_mode = false;
-
-            // Write flash.
-            lib_config::write_flash(&mut flash, config).await;
-        }
-        Err(e) => error!("Failed to read flash: {:?}", e),
-    }
+    CHANNEL_FLASH.send(FlashConfigMessages::ValetOn).await;
 
     #[allow(clippy::empty_loop)]
     loop {}


### PR DESCRIPTION
I think I've determined (with .. 98% certainty) that the resets I've been experiencing is due to the flash being accessed *while* "something" else is happening.

From what little I understand of documentations "out there", it seems you can't use the flash *while* also using some of the
GPIO pins (which ones varies between pages and documentation!) - most notably (which is my _current_ working theory), the ADC/GPIO#28 which I use for reading the actuator brush.

It *DOES* seem to *always* reset when the actuator is moving. I *thought* it was due to some spike or "something" from the actuator, but because I can use the actuator alone in the `test-actuator` program, it seem unlikely.

So need to rewrite the flash somehow, because everything works just fine if I disable all the flash code. I will need a N:1 and 1:N message handler. Not sure how to do that though...

What uses the flash and why:
  * Main: Move actuator to saved position when starting.
  * Actuator: Update on position change.
  * Buttons: Update on valet mode toggle.

So these three functions will need to send messages to the (new) flash controller, that acts on this (read/write flash), then it needs to send a/the response back to the (right!) requester.